### PR TITLE
note about renaming results to analysis and minor readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 Templates
 ---------
 
+Project directory structure
+===========================
+See [project_structures.md](project_structures.md)
+
 Building command line application using Ruby
 ============================================
 

--- a/project_structures.md
+++ b/project_structures.md
@@ -51,6 +51,9 @@ Conventions include:
 * every directory in which you did something should contain a `WHATIDID.txt` (or an equivalent ruby/perl/jupyter/R/knitR script) that contains all relevant commands. required to get from `input` to `results`.
 * once you have created an "input" (i.e. "data") folder, make it read-only because you don't want any accidental edits while you are running your analysis
 
+## Other ideas
+* maybe `results` should be called `analysis`
+
 
 ## Credit: 
 This was derived from [A Quick Guide to Organizing Computational Biology Projects](http://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1000424) with input (a while ago) from others including Julien Roux.

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -29,4 +29,4 @@ sequences in FASTA format.
 This template automatically takes input files as here: `bundle exec bin/appname input1.fq input2.fq`.
 
 Any string output like  `puts "ACAGTAGCAGTCAGC"` will display in standard output - thus output can be redirected with `>`.
-Errors (and logging info) should be displayed in standard error by `STDERR.puts "I did a great job.".
+Errors (and logging info) should be displayed in standard error by `STDERR.puts "I did a great job."`.


### PR DESCRIPTION
-  Add note about renaming `results` to `analysis`.
- Add link to project_structures.md in README. Otherwise it looks like the repository is just for ruby.